### PR TITLE
feat: Add <CountUp /> TextAnimation

### DIFF
--- a/src/lib/components/docs/pages/CountUpDemo.svelte
+++ b/src/lib/components/docs/pages/CountUpDemo.svelte
@@ -1,0 +1,132 @@
+<script lang="ts">
+	import TabsLayout from '$lib/components/docs/preview/TabsLayout.svelte';
+	import Customize from '$lib/components/docs/preview/Customize.svelte';
+	import PreviewSlider from '$lib/components/docs/preview/PreviewSlider.svelte';
+	import PreviewSelect from '$lib/components/docs/preview/PreviewSelect.svelte';
+	import PreviewInput from '$lib/components/docs/preview/PreviewInput.svelte';
+	import PropTable, { type PropRow } from '$lib/components/docs/preview/PropTable.svelte';
+	import DemoCodeTab from '$lib/components/docs/preview/DemoCodeTab.svelte';
+	import ReplayButton from '$lib/components/docs/preview/ReplayButton.svelte';
+	import CountUp from '$lib/components/library/TextAnimations/CountUp/CountUp.svelte';
+	import countUpSource from '$lib/components/library/TextAnimations/CountUp/CountUp.svelte?raw';
+
+	const DEFAULTS = {
+		from: 0,
+		to: 100,
+		duration: 1,
+		delay: 0,
+		direction: 'up' as 'up' | 'down',
+		separator: ','
+	};
+
+	let from = $state(DEFAULTS.from);
+	let to = $state(DEFAULTS.to);
+	let duration = $state(DEFAULTS.duration);
+	let delay = $state(DEFAULTS.delay);
+	let direction = $state<'up' | 'down'>(DEFAULTS.direction);
+	let separator = $state(DEFAULTS.separator);
+
+	let replay = $state(0);
+
+	const hasChanges = $derived(
+		from !== DEFAULTS.from ||
+			to !== DEFAULTS.to ||
+			duration !== DEFAULTS.duration ||
+			delay !== DEFAULTS.delay ||
+			direction !== DEFAULTS.direction ||
+			separator !== DEFAULTS.separator
+	);
+
+	function reset() {
+		from = DEFAULTS.from;
+		to = DEFAULTS.to;
+		duration = DEFAULTS.duration;
+		delay = DEFAULTS.delay;
+		direction = DEFAULTS.direction;
+		separator = DEFAULTS.separator;
+		replay++;
+	}
+
+	const usage = $derived(`${'<' + 'script lang="ts">'}
+  import CountUp from '$lib/components/CountUp.svelte';
+${'</' + 'script>'}
+
+<CountUp
+  from={${from}}
+  to={${to}}
+  separator="${separator}"
+  direction="${direction}"
+  duration={${duration}}
+  delay={${delay}}
+/>`);
+
+	const props: PropRow[] = [
+		{ name: 'to', type: 'number', default: '-', description: 'The target number to count up to.' },
+		{ name: 'from', type: 'number', default: '0', description: 'The initial number from which the count starts.' },
+		{ name: 'direction', type: 'string', default: '"up"', description: 'Direction of the count; can be "up" or "down". When this is set to "down", "from" and "to" become reversed, in order to count down.' },
+		{ name: 'delay', type: 'number', default: '0', description: 'Delay in seconds before the counting starts.' },
+		{ name: 'duration', type: 'number', default: '2', description: 'Duration of the count animation - based on the damping and stiffness configured inside the component.' },
+		{ name: 'class', type: 'string', default: '""', description: 'CSS class to apply to the component for additional styling.' },
+		{ name: 'startWhen', type: 'boolean', default: 'true', description: 'A boolean to control whether the animation should start when the component is in view. It basically works like an if statement, if this is true, the count will start.' },
+		{ name: 'separator', type: 'string', default: '""', description: 'Character to use as a thousands separator in the displayed number.' },
+		{ name: 'onStart', type: 'function', default: '-', description: 'Callback function that is called when the count animation starts.' },
+		{ name: 'onEnd', type: 'function', default: '-', description: 'Callback function that is called when the count animation ends.' }
+	];
+</script>
+
+<svelte:head>
+	<title>Count Up - svelte-bits</title>
+</svelte:head>
+
+<h1 class="sub-category">Count Up</h1>
+
+<TabsLayout onreset={reset} {hasChanges} componentName="CountUp" {usage} source={countUpSource} {props}>
+	{#snippet preview()}
+		<div style="position:relative;min-height:400px;display:flex;align-items:center;justify-content:center;width:100%;font-size:80px;font-weight:700;">
+			<ReplayButton onClick={() => replay++} />
+			{#key replay}
+				<CountUp {from} {to} {duration} {delay} {direction} {separator} />
+			{/key}
+		</div>
+	{/snippet}
+	{#snippet code()}
+		<DemoCodeTab slug="count-up" {usage} source={countUpSource} />
+	{/snippet}
+	{#snippet customize()}
+		<Customize>
+			<PreviewSlider title="To" min={0} max={10000} step={100} value={to}
+				onChange={(v) => { to = v; replay++; }} />
+			<PreviewSlider title="From" min={0} max={1000} step={10} value={from}
+				onChange={(v) => { from = v; replay++; }} />
+			<PreviewSlider title="Duration" min={0.5} max={10} step={0.5} value={duration} valueUnit="s"
+				onChange={(v) => (duration = v)} />
+			<PreviewSlider title="Delay" min={0} max={5} step={0.5} value={delay} valueUnit="s"
+				onChange={(v) => (delay = v)} />
+			<PreviewSelect
+				title="Direction"
+				options={[
+					{ label: 'Up', value: 'up' },
+					{ label: 'Down', value: 'down' }
+				]}
+				value={direction}
+				onChange={(v) => {
+					direction = v as 'up' | 'down';
+					replay++;
+				}}
+			/>
+			<PreviewInput
+				title="Separator"
+				value={separator}
+				placeholder=","
+				maxlength={1}
+				onChange={(v) => {
+					separator = v.slice(-1);
+					replay++;
+				}}
+			/>
+		</Customize>
+	{/snippet}
+	{#snippet propTable()}
+		<PropTable rows={props} />
+	{/snippet}
+</TabsLayout>

--- a/src/lib/components/docs/pages/demoRegistry.ts
+++ b/src/lib/components/docs/pages/demoRegistry.ts
@@ -28,5 +28,6 @@ export const DOC_PAGE_REGISTRY: Record<string, DemoLoader> = {
 	'splash-cursor': () => import('./SplashCursorDemo.svelte'),
 	'split-text': () => import('./SplitTextDemo.svelte'),
 	'star-border': () => import('./StarBorderDemo.svelte'),
-	'true-focus': () => import('./TrueFocusDemo.svelte')
+	'true-focus': () => import('./TrueFocusDemo.svelte'),
+	'count-up': () => import('./CountUpDemo.svelte')
 };

--- a/src/lib/components/docs/preview/PreviewInput.svelte
+++ b/src/lib/components/docs/preview/PreviewInput.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	type Props = {
+		title?: string;
+		value?: string;
+		placeholder?: string;
+		maxlength?: number;
+		isDisabled?: boolean;
+		onChange?: (v: string) => void;
+	};
+
+	let {
+		title = '',
+		value = '',
+		placeholder = '',
+		maxlength,
+		isDisabled = false,
+		onChange
+	}: Props = $props();
+</script>
+
+<div class="scrubber">
+	<div class="scrubber-track scrubber-track--input" data-disabled={isDisabled}>
+		<span class="scrubber-label">{title}</span>
+		<input
+			class="scrubber-input"
+			type="text"
+			{value}
+			{placeholder}
+			{maxlength}
+			disabled={isDisabled}
+			aria-label={title}
+			oninput={(e) => onChange?.((e.target as HTMLInputElement).value)}
+		/>
+	</div>
+</div>

--- a/src/lib/components/library/TextAnimations/CountUp/CountUp.svelte
+++ b/src/lib/components/library/TextAnimations/CountUp/CountUp.svelte
@@ -1,0 +1,123 @@
+<!-- @svelte-bits
+{
+  "title": "Count Up",
+  "description": "Spring-animated number counter that counts up (or down) when scrolled into view, with configurable spring physics, delay, and number formatting.",
+  "dependencies": ["motion"]
+}
+-->
+<script lang="ts">
+	import { animate } from 'motion';
+
+	type Props = {
+		to: number;
+		from?: number;
+		direction?: 'up' | 'down';
+		delay?: number;
+		duration?: number;
+		class?: string;
+		startWhen?: boolean;
+		separator?: string;
+		onStart?: () => void;
+		onEnd?: () => void;
+	};
+
+	let {
+		to,
+		from = 0,
+		direction = 'up',
+		delay = 0,
+		duration = 2,
+		class: className = '',
+		startWhen = true,
+		separator = '',
+		onStart,
+		onEnd
+	}: Props = $props();
+
+	let spanEl: HTMLSpanElement | undefined = $state();
+	let inView = $state(false);
+
+	function getDecimalPlaces(num: number): number {
+		const str = num.toString();
+		if (str.includes('.')) {
+			const decimals = str.split('.')[1];
+			if (parseInt(decimals) !== 0) return decimals.length;
+		}
+		return 0;
+	}
+
+	const maxDecimals = $derived(Math.max(getDecimalPlaces(from), getDecimalPlaces(to)));
+
+	function formatValue(latest: number, decimals: number, sep: string): string {
+		const hasDecimals = decimals > 0;
+		const options: Intl.NumberFormatOptions = {
+			useGrouping: !!sep,
+			minimumFractionDigits: hasDecimals ? decimals : 0,
+			maximumFractionDigits: hasDecimals ? decimals : 0
+		};
+		const formatted = Intl.NumberFormat('en-US', options).format(latest);
+		return sep ? formatted.replace(/,/g, sep) : formatted;
+	}
+
+	$effect(() => {
+		if (spanEl) {
+			spanEl.textContent = formatValue(direction === 'down' ? to : from, maxDecimals, separator);
+		}
+	});
+
+	$effect(() => {
+		if (!spanEl) return;
+		const el = spanEl;
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				if (entry.isIntersecting) {
+					inView = true;
+					observer.unobserve(el);
+				}
+			},
+			{ threshold: 0 }
+		);
+		observer.observe(el);
+		return () => observer.disconnect();
+	});
+
+	$effect(() => {
+		if (!inView || !startWhen || !spanEl) return;
+
+		const el = spanEl;
+		const decimals = maxDecimals;
+		const sep = separator;
+		const damping = 20 + 40 * (1 / duration);
+		const stiffness = 100 * (1 / duration);
+		const startValue = direction === 'down' ? to : from;
+		const endValue = direction === 'down' ? from : to;
+
+		onStart?.();
+
+		let stopFn: (() => void) | undefined;
+
+		const startTimeout = setTimeout(() => {
+			const controls = animate(startValue, endValue, {
+				type: 'spring',
+				damping,
+				stiffness,
+				onUpdate: (latest: number) => {
+					if (el) el.textContent = formatValue(latest, decimals, sep);
+				}
+			});
+			stopFn = () => controls.stop();
+		}, delay * 1000);
+
+		const endTimeout = setTimeout(() => {
+			onEnd?.();
+		}, (delay + duration) * 1000);
+
+		return () => {
+			clearTimeout(startTimeout);
+			clearTimeout(endTimeout);
+			stopFn?.();
+		};
+	});
+</script>
+
+<span bind:this={spanEl} class={className}></span>

--- a/src/lib/constants/categories.ts
+++ b/src/lib/constants/categories.ts
@@ -1,5 +1,6 @@
 export const NEW: string[] = [
-	'True Focus'
+	'True Focus',
+	'Count Up'
 ];
 
 export const UPDATED: string[] = [
@@ -204,6 +205,7 @@ export const IMPLEMENTED_DEMOS = new Set<string>([
 	'hyperspeed',
 	'flying-posters',
 	'true-focus',
+	'count-up'
 ]);
 
 // Helper: is this subcategory label fully ported?

--- a/src/lib/constants/componentDependencies.ts
+++ b/src/lib/constants/componentDependencies.ts
@@ -12,7 +12,8 @@ export const COMPONENT_DEPENDENCIES: Record<string, string[]> = {
 	'liquid-ether': ['three'],
 	'magic-rings': ['three'],
 	'split-text': ['gsap'],
-	'true-focus': ['motion']
+	'true-focus': ['motion'],
+	'count-up': ['motion']
 };
 
 export function dependenciesForSlug(slug: string | undefined): string[] {

--- a/src/lib/css/preview.css
+++ b/src/lib/css/preview.css
@@ -275,6 +275,33 @@
 	flex-shrink: 0;
 }
 
+/* Input */
+.scrubber-track--input {
+	cursor: default;
+}
+
+.scrubber-input {
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	background: none;
+	border: none;
+	outline: none;
+	color: var(--text-primary);
+	font-family: 'Geist Mono', ui-monospace, monospace;
+	font-size: 13px;
+	padding: 0 12px 0 40%;
+	text-align: right;
+	text-overflow: ellipsis;
+	z-index: 4;
+}
+
+.scrubber-input::placeholder {
+	color: rgba(255, 255, 255, 0.25);
+}
+
 /* ─── Prop Table ───────────────────────────────────────────────────────────── */
 .prop-table-section {
 	margin-top: 3em;

--- a/static/r/count-up.json
+++ b/static/r/count-up.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "count-up",
+  "type": "registry:component",
+  "title": "Count Up",
+  "description": "Spring-animated number counter that counts up (or down) when scrolled into view, with configurable spring physics, delay, and number formatting.",
+  "categories": [
+    "text-animations"
+  ],
+  "files": [
+    {
+      "path": "CountUp.svelte",
+      "content": "<script lang=\"ts\">\n\timport { animate } from 'motion';\n\n\ttype Props = {\n\t\tto: number;\n\t\tfrom?: number;\n\t\tdirection?: 'up' | 'down';\n\t\tdelay?: number;\n\t\tduration?: number;\n\t\tclass?: string;\n\t\tstartWhen?: boolean;\n\t\tseparator?: string;\n\t\tonStart?: () => void;\n\t\tonEnd?: () => void;\n\t};\n\n\tlet {\n\t\tto,\n\t\tfrom = 0,\n\t\tdirection = 'up',\n\t\tdelay = 0,\n\t\tduration = 2,\n\t\tclass: className = '',\n\t\tstartWhen = true,\n\t\tseparator = '',\n\t\tonStart,\n\t\tonEnd\n\t}: Props = $props();\n\n\tlet spanEl: HTMLSpanElement | undefined = $state();\n\tlet inView = $state(false);\n\n\tfunction getDecimalPlaces(num: number): number {\n\t\tconst str = num.toString();\n\t\tif (str.includes('.')) {\n\t\t\tconst decimals = str.split('.')[1];\n\t\t\tif (parseInt(decimals) !== 0) return decimals.length;\n\t\t}\n\t\treturn 0;\n\t}\n\n\tconst maxDecimals = $derived(Math.max(getDecimalPlaces(from), getDecimalPlaces(to)));\n\n\tfunction formatValue(latest: number, decimals: number, sep: string): string {\n\t\tconst hasDecimals = decimals > 0;\n\t\tconst options: Intl.NumberFormatOptions = {\n\t\t\tuseGrouping: !!sep,\n\t\t\tminimumFractionDigits: hasDecimals ? decimals : 0,\n\t\t\tmaximumFractionDigits: hasDecimals ? decimals : 0\n\t\t};\n\t\tconst formatted = Intl.NumberFormat('en-US', options).format(latest);\n\t\treturn sep ? formatted.replace(/,/g, sep) : formatted;\n\t}\n\n\t$effect(() => {\n\t\tif (spanEl) {\n\t\t\tspanEl.textContent = formatValue(direction === 'down' ? to : from, maxDecimals, separator);\n\t\t}\n\t});\n\n\t$effect(() => {\n\t\tif (!spanEl) return;\n\t\tconst el = spanEl;\n\t\tconst observer = new IntersectionObserver(\n\t\t\t([entry]) => {\n\t\t\t\tif (entry.isIntersecting) {\n\t\t\t\t\tinView = true;\n\t\t\t\t\tobserver.unobserve(el);\n\t\t\t\t}\n\t\t\t},\n\t\t\t{ threshold: 0 }\n\t\t);\n\t\tobserver.observe(el);\n\t\treturn () => observer.disconnect();\n\t});\n\n\t$effect(() => {\n\t\tif (!inView || !startWhen || !spanEl) return;\n\n\t\tconst el = spanEl;\n\t\tconst decimals = maxDecimals;\n\t\tconst sep = separator;\n\t\tconst damping = 20 + 40 * (1 / duration);\n\t\tconst stiffness = 100 * (1 / duration);\n\t\tconst startValue = direction === 'down' ? to : from;\n\t\tconst endValue = direction === 'down' ? from : to;\n\n\t\tonStart?.();\n\n\t\tlet stopFn: (() => void) | undefined;\n\n\t\tconst startTimeout = setTimeout(() => {\n\t\t\tconst controls = animate(startValue, endValue, {\n\t\t\t\ttype: 'spring',\n\t\t\t\tdamping,\n\t\t\t\tstiffness,\n\t\t\t\tonUpdate: (latest: number) => {\n\t\t\t\t\tif (el) el.textContent = formatValue(latest, decimals, sep);\n\t\t\t\t}\n\t\t\t});\n\t\t\tstopFn = () => controls.stop();\n\t\t}, delay * 1000);\n\n\t\tconst endTimeout = setTimeout(() => {\n\t\t\tonEnd?.();\n\t\t}, (delay + duration) * 1000);\n\n\t\treturn () => {\n\t\t\tclearTimeout(startTimeout);\n\t\t\tclearTimeout(endTimeout);\n\t\t\tstopFn?.();\n\t\t};\n\t});\n</script>\n\n<span bind:this={spanEl} class={className}></span>\n",
+      "type": "registry:component",
+      "target": "$lib/components/svelte-bits/CountUp.svelte"
+    }
+  ],
+  "dependencies": [
+    "motion"
+  ]
+}

--- a/static/r/registry.json
+++ b/static/r/registry.json
@@ -260,6 +260,22 @@
       ]
     },
     {
+      "name": "count-up",
+      "type": "registry:component",
+      "title": "Count Up",
+      "description": "Spring-animated number counter that counts up (or down) when scrolled into view, with configurable spring physics, delay, and number formatting.",
+      "categories": [
+        "text-animations"
+      ],
+      "files": [
+        {
+          "path": "CountUp.svelte",
+          "type": "registry:component",
+          "target": "$lib/components/svelte-bits/CountUp.svelte"
+        }
+      ]
+    },
+    {
       "name": "glitch-text",
       "type": "registry:component",
       "title": "Glitch Text",


### PR DESCRIPTION
Ports the [CountUp](https://www.reactbits.dev/text-animations/count-up) component from React Bits into Svelte Bits, preserving the original animation behaviour, physics, props, and demo controls.

<img width="3840" height="4016" alt="svelte-bits-countup" src="https://github.com/user-attachments/assets/83fbfc8a-f2ba-40a2-8126-8f1ebb055e8e" />

---

## What's included
**New component**
- `src/lib/components/library/TextAnimations/CountUp/CountUp.svelte`: Spring-animated number counter powered by `motion`. Counts up (or down) when scrolled into view via `IntersectionObserver`. Spring damping and stiffness are derived from the `duration` prop, matching the React Bits formula exactly. Number formatting uses `Intl.NumberFormat` with optional thousands separator and automatic decimal precision detection.

**New demo page**
- `src/lib/components/docs/pages/CountUpDemo.svelte`: Interactive demo with sliders for `to`, `from`, `duration`, `delay`, a direction select, and a free-text separator input, matching the React Bits demo controls.

**New reusable preview control**
- `src/lib/components/docs/preview/PreviewInput.svelte`: Text input variant of the shared scrubber UI, ported from React Bits' `PreviewInput.jsx`. Usable by any future demo that needs a free-text control.
- `src/lib/css/preview.css`: added `scrubber-track--input` and `scrubber-input` CSS block to the existing preview style system.

**Registry & wiring**
- `src/lib/constants/categories.ts`: added `count-up` to `IMPLEMENTED_DEMOS` and `NEW`
- `src/lib/constants/componentDependencies.ts`: added `'count-up': ['motion']`
- `src/lib/components/docs/pages/demoRegistry.ts`: added lazy import for `CountUpDemo`
- `static/r/count-up.json`: generated registry item
- `static/r/registry.json`: updated index

## Dependency
`motion` already listed in `package.json`.

## Checklist
- [x] Component is a faithful port of the [React Bits CountUp](https://www.reactbits.dev/text-animations/count-up) same spring physics, props, defaults, and demo controls
- [x] Tested locally in the browser: animation, replay, all controls, direction toggle, separator input
- [x] `npm run svelte-check` passes with no errors or warnings
- [x] `npm run build` completes with no errors. `static/r/count-up.json` and `static/r/registry.json` updated
- [x] `PreviewInput` is a generic reusable control, not CountUp-specific