### PR TITLE
fix: restore count-up registry entry and NEW badge removed by PR #3

### DIFF
--- a/src/lib/constants/categories.ts
+++ b/src/lib/constants/categories.ts
@@ -1,4 +1,8 @@
-export const NEW: string[] = ["True Focus", "Falling Text"];
+export const NEW: string[] = [
+	"True Focus",
+	"Count Up",
+	"Falling Text"
+];
 
 export const UPDATED: string[] = [
 

--- a/static/r/registry.json
+++ b/static/r/registry.json
@@ -260,6 +260,22 @@
       ]
     },
     {
+      "name": "count-up",
+      "type": "registry:component",
+      "title": "Count Up",
+      "description": "Spring-animated number counter that counts up (or down) when scrolled into view, with configurable spring physics, delay, and number formatting.",
+      "categories": [
+        "text-animations"
+      ],
+      "files": [
+        {
+          "path": "CountUp.svelte",
+          "type": "registry:component",
+          "target": "$lib/components/svelte-bits/CountUp.svelte"
+        }
+      ]
+    },
+    {
       "name": "falling-text",
       "type": "registry:component",
       "title": "Falling Text",


### PR DESCRIPTION
## Summary

- Restores the `count-up` entry in `static/r/registry.json` that was accidentally overwritten by the Falling Text PR #3 
- Adds `"Count Up"` back to the `NEW` array in `src/lib/constants/categories.ts` alongside `"Falling Text"`

## Root Cause

PR #3 introduced a merge conflict in `registry.json` that was incorrectly resolved by replacing the `count-up` block with the new `falling-text` block instead of appending it.

<img width="1899" height="1008" alt="Screenshot 2026-05-04 at 11 19 44 AM" src="https://github.com/user-attachments/assets/8a90c935-c0e2-4775-906a-9b2fa95ed99a" />

---

The same conflict in `categories.ts` resulted in `"Count Up"` being dropped from the `NEW` array.

<img width="1899" height="1008" alt="Screenshot 2026-05-04 at 11 22 23 AM" src="https://github.com/user-attachments/assets/a1292bab-2fea-4c2c-90ca-153d3124eb1c" />


## Files Changed

- `static/r/registry.json`: Re-added `count-up` entry
- `src/lib/constants/categories.ts`: Updated `NEW` array to:
  ```ts
  ["True Focus", "Count Up", "Falling Text"]
  ```

## Suggestion

Hello @DavidHDev, Would it be better if `static/r/registry.json` or all registry json files, since they appears to be auto-generated, to be added to `.gitignore` or handled via a CI step that regenerates them?

This might help prevent it from showing up in PRs and reduce the chances of similar conflicts happening again.